### PR TITLE
fix `draw_grid` function and some minor changes

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,14 @@
 import sys
 import numpy as np
 import pygame
+import pygame.gfxdraw
+
 
 pygame.init()
 pygame.display.init()
 screen_size = 1080, 720
 screen = pygame.display.set_mode(screen_size)
-fps = 30
+fps = 240
 clock = pygame.time.Clock()
 
 black = 0
@@ -17,8 +19,7 @@ square_size = 10
 
 rows, cols = int(screen_size[1] / square_size), int(screen_size[0] / square_size)
 
-
-grid = np.zeros((rows, cols))
+grid = np.zeros((rows, cols), dtype=np.uint8)
 print(f"\n{grid}\n")
 print(
     f"Screen size: {screen_size[0]}x{screen_size[1]}\n"
@@ -38,23 +39,21 @@ class Ant:
 
     def turn_right(self):
         self.direction += 1
-        if self.direction > self.ANT_LEFT:
-            self.direction = self.ANT_UP
+        self.direction %= 4
 
     def turn_left(self):
         self.direction -= 1
-        if self.direction < self.ANT_UP:
-            self.direction = self.ANT_LEFT
+        self.direction %= 4
 
     def on_zero(self):
         # print("Checking square color")
         # print(not grid[self.position[1]][self.position[0]])
-        return not grid[self.position[1]][self.position[0]]
+        return not grid[self.position[1], self.position[0]]
 
     def switch_color(self):
         # print("Switching color")
-        grid[self.position[1]][self.position[0]] = 1 \
-            if not grid[self.position[1]][self.position[0]] else 0
+        grid[self.position[1], self.position[0]] = 1 \
+            if not grid[self.position[1], self.position[0]] else 0
 
     def move(self):
         if self.direction == self.ANT_UP:
@@ -92,7 +91,7 @@ class Ant:
 # TODO: fix this function instead of using the other slooooow one
 """
 def display(surface):
-    display_surf = pygame.Surface((rows, cols))
+    display_surf = pygame.Surface(grid.shape)
     display_grid = (grid*color_b) + (1-grid)*color_a
     pygame.surfarray.blit_array(display_surf, display_grid)
     scaled_surf = pygame.transform.scale(display_surf, surface.get_size())
@@ -105,7 +104,7 @@ def display(surface):
     x, y = 0, 0
     for row in grid:
         for col in row:
-            pygame.draw.rect(surface, color_a if not col else color_b, (x, y, square_size, square_size))
+            pygame.draw.rect(surface, color_b if col else color_a, (x, y, square_size, square_size))
             x = x + square_size
         y = y + square_size
         x = 0
@@ -113,12 +112,14 @@ def display(surface):
 
 def draw_grid():
     for x in range(0, screen_size[0], square_size):
-        for y in range(0, screen_size[1], square_size):
-            rect = pygame.Rect(x, y, square_size, square_size)
-            pygame.draw.rect(screen, black, rect, 1)
+        pygame.gfxdraw.vline(screen, x, 0, screen_size[1], (0, 0, 0))
+    for y in range(0, screen_size[1], square_size):
+        pygame.gfxdraw.hline(screen, 0, screen_size[0], y, (0, 0, 0))
 
 
 ant = Ant((cols / 2, rows / 2), 1)
+
+
 # ant1 = Ant((cols / 2.5, rows / 2), 2)
 # ant2 = Ant((cols / 1.8, rows / 2), 3)
 # ant3 = Ant((cols / 3, rows / 2), 4)
@@ -128,7 +129,7 @@ def main():
     steps = 0
 
     while True:
-        clock.tick(240)
+        clock.tick(fps)
 
         # Exit on ESCAPE key press or if the user presses the X button on the window
         for event in pygame.event.get():
@@ -145,13 +146,14 @@ def main():
         display(screen)
         draw_grid()
         pygame.display.flip()
-
+        pygame.display.set_caption(f"LANGTON'S ANTS ({clock.get_fps()}/{fps})")
         steps += 1
         """
         if steps >= 100:
             print(f"\n{steps} steps in {pygame.time.get_ticks()} ms")
             sys.exit()
         """
+
 
 if __name__ == "__main__":
     main()

--- a/main.py
+++ b/main.py
@@ -52,8 +52,7 @@ class Ant:
 
     def switch_color(self):
         # print("Switching color")
-        grid[self.position[1], self.position[0]] = 1 \
-            if not grid[self.position[1], self.position[0]] else 0
+        grid[self.position[1], self.position[0]] = not grid[self.position[1], self.position[0]]
 
     def move(self):
         if self.direction == self.ANT_UP:

--- a/main.py
+++ b/main.py
@@ -135,6 +135,7 @@ def main():
             if event.type == pygame.QUIT or \
                     event.type == pygame.KEYDOWN and \
                     event.key == pygame.K_ESCAPE:
+                print(steps)
                 sys.exit()
 
         ant.step()


### PR DESCRIPTION
The changes are:
- Use the `pygame.gfxdraw.hline` and `pygame.gfxdraw.vline` instead of drawing rectangles (this triplicated the speed of the program)
- Specify the type of the grid array (`np.uint8`). Using floats gives poor performance.
- Change all ` grid[self.position[1]][self.position[0]]` to `grid[self.position[1], self.position[0]]`. The former indexes a column of the array, then an element of the new array (this implies you allocate a copy of a piece of the array in memory every time you index something, which would be really slow). The new method just indexes the element (there is no new allocation at all).